### PR TITLE
Added support for saving trajectories

### DIFF
--- a/Group9_FinalProject/Agent.py
+++ b/Group9_FinalProject/Agent.py
@@ -46,6 +46,7 @@ class Agent:
         self.next_state = float("nan")
         self.reward = float("nan")
         self.game_over = float("nan")
+        self.action = float("nan")
     
     def get_action(self, state):
 
@@ -53,7 +54,8 @@ class Agent:
         # that this random sampling does not interfere/ interact with seed 
         # setting studd elsewhere
         self.state = state
-        return np.random.choice(self.action_space, size=1)[0]
+        self.action = np.random.choice(self.action_space, size=1)[0]
+        return self.action
 
     def inform_result(self, next_state, reward, game_over):
 

--- a/Group9_FinalProject/DQNAgent.py
+++ b/Group9_FinalProject/DQNAgent.py
@@ -6,13 +6,7 @@ from Agent import Agent
 
 class DQNAgent(Agent):
     def __init__(self, model, action_space:np.ndarray, gamma=0.9, epsilon=1.0, epsilon_decay=0.97, epsilon_floor = 0.1):
-        # call the super
-        self.action_space = action_space
-        self.state = float("nan")
-        self.next_state = float("nan")
-        self.reward = float("nan")
-        self.game_over = float("nan")
-        self.action = float("nan")
+        super().__init__(action_space)
 
         self.model = model
         self.loss_fn = torch.nn.MSELoss()

--- a/Group9_FinalProject/Orchestrator.py
+++ b/Group9_FinalProject/Orchestrator.py
@@ -4,6 +4,7 @@ from matplotlib import colors
 from Agent import Agent
 from GridWorld import GridWorld
 from util_classes import *
+import pickle
 
 
 """
@@ -30,6 +31,7 @@ class Orchestrator:
         self.game = game
         self.agent = agent
         self.num_games = num_games
+        self.trajectories = [] # should trajectories belong to agents?
     
     def play(self):
 
@@ -39,6 +41,7 @@ class Orchestrator:
             # intialize the game
             self.game.reset()
             self.agent.reset() 
+            self.trajectories.append([])
 
             # get initial state and whether game is over
             init_state = self.game.get_state()
@@ -55,6 +58,9 @@ class Orchestrator:
 
                 # get next_state, reward, and whether the game was won
                 next_state, reward, game_over = self.game.step(action)
+
+                # add data to trajectories
+                self.trajectories[-1].append((state, action, reward, next_state, game_over))
 
                 # inform the agent of the result
                 self.agent.inform_result(next_state, reward, game_over)
@@ -74,4 +80,13 @@ class Orchestrator:
     
     def set_agent(self, agent):
         """ sets the agent controlled by the orchestrator """
+        self.agent = agent
 
+    def save_trajectories(self, filepath='trajectories.pkl'):
+        with open(filepath, 'wb') as file:
+            states, actions, rewards, next_states, dones = split_trajectories(self.trajectories)
+            pickle.dump({'state':states,
+                         'actions':actions,
+                         'rewards':rewards,
+                         'next_states':next_states,
+                         'dones':dones}, file)

--- a/Group9_FinalProject/main.py
+++ b/Group9_FinalProject/main.py
@@ -37,6 +37,7 @@ def main():
     orchestrator = Orchestrator(game=game, agent=agent, num_games=NUM_GAMES)
     
     orchestrator.play()
+    orchestrator.save_trajectories()
 
     agent.print_results()
 

--- a/Group9_FinalProject/util_classes.py
+++ b/Group9_FinalProject/util_classes.py
@@ -4,3 +4,15 @@ class Position:
     def __init__(self, x, y):
         self.x=x
         self.y=y
+
+# traj = [[s, a, r, s'], [s, a, r, s'], ...]
+# trajectories = [[[s, a, r, s'], [s, a, r, s'], ...], [...], [...], ...]
+def split_trajectories(trajectories):
+    num_trajectories = len(trajectories)
+    states = [[step[0] for step in trajectories[i]] for i in range(num_trajectories)]
+    actions = [[step[1] for step in trajectories[i]] for i in range(num_trajectories)]
+    rewards = [[step[2] for step in trajectories[i]] for i in range(num_trajectories)]
+    next_states = [[step[3] for step in trajectories[i]] for i in range(num_trajectories)]
+    dones = [[step[4] for step in trajectories[i]] for i in range(num_trajectories)]
+
+    return states, actions, rewards, next_states, dones


### PR DESCRIPTION
1. Added support for saving trajectories. The Orchestrator keeps track of them as it passes states and actions between the Agent and the GridWorld. I wasn't sure if trajectories should belong to the base Agent class but I decided to go with just the Orchestrator because it seemed simpler. An agent in general might not need to keep track of its own trajectories, but a DQN agent might need to keep track of trajectories, but I think those belong in a replay buffer which might be the same kind of data structure but I think serves a different purpose.

2. Added action member variable to the base Agent class, and let the DQN Agent call its parent's constructor.

Other thoughts:
Maybe the pickle file that we save to should have its name determined by how the Orchestrator runs things. So maybe the filename would have the Agent class name in it (DQNAgent vs Agent) and the number of games played.

The trajectory data mirrors what the IQ Learn people did, but I'm not sure if there's necessarily a benefit to their way of doing it (states separated out, actions separated out, etc)  vs just plain lists of (state, action, reward, next_state, done) tuples.